### PR TITLE
adds additional imported module namespaces to be added in codegen

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegenConfiguration.swift
@@ -921,6 +921,8 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
 
   /// Name used to scope the generated schema type files.
   public let schemaNamespace: String
+  /// Names used to add additional scopes the generated schema type files.
+  public let additionalImportedModuleNamespaces: [String]
   /// The input files required for code generation.
   public let input: FileInput
   /// The paths and files output by code generation.
@@ -960,6 +962,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
   ///  - experimentalFeatures: Allows users to enable experimental features.
   public init(
     schemaNamespace: String,
+    additionalImportedModuleNamespaces: [String] = [],
     input: FileInput,
     output: FileOutput,
     options: OutputOptions = Default.options,
@@ -968,6 +971,7 @@ public struct ApolloCodegenConfiguration: Codable, Equatable {
     operationManifest: OperationManifestConfiguration? = Default.operationManifest
   ) {
     self.schemaNamespace = schemaNamespace
+    self.additionalImportedModuleNamespaces = additionalImportedModuleNamespaces
     self.input = input
     self.output = output
     self.options = options

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -287,6 +287,12 @@ struct ImportStatementTemplate {
       return """
       @_exported import \(apolloAPITargetName)
       \(if: config.output.operations != .inSchemaModule, "import \(config.schemaModuleName)")
+      \(forEachIn: config.additionalImportedModulesNames, {
+        guard config.output.operations != .inSchemaModule else {
+          return nil
+        }
+        return "import \($0)"
+      })
       """
     }
   }
@@ -306,6 +312,12 @@ fileprivate extension ApolloCodegenConfiguration {
     switch output.schemaTypes.moduleType {
     case let .embeddedInTarget(targetName, _): return targetName
     case .swiftPackageManager, .other: return schemaNamespace.firstUppercased
+    }
+  }
+  var additionalImportedModulesNames: [String] {
+    switch output.schemaTypes.moduleType {
+    case .embeddedInTarget: return []
+    case .swiftPackageManager, .other: return additionalImportedModuleNamespaces.map { $0.firstUppercased }
     }
   }
 }

--- a/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
+++ b/Sources/ApolloCodegenLib/Templates/TemplateRenderer.swift
@@ -288,9 +288,6 @@ struct ImportStatementTemplate {
       @_exported import \(apolloAPITargetName)
       \(if: config.output.operations != .inSchemaModule, "import \(config.schemaModuleName)")
       \(forEachIn: config.additionalImportedModulesNames, {
-        guard config.output.operations != .inSchemaModule else {
-          return nil
-        }
         return "import \($0)"
       })
       """


### PR DESCRIPTION
The purpose of this change is to give codegen the capability to add custom import statements to generated operations.
This change would enable the consumer to share fragments across generated packages.

Addresses this thread: 

https://github.com/apollographql/apollo-ios/issues/3284