### PR TITLE
fix: Work around swift compiler issue triggered in compileGraphQLResult()

### DIFF
--- a/Sources/ApolloCodegenLib/ApolloCodegen.swift
+++ b/Sources/ApolloCodegenLib/ApolloCodegen.swift
@@ -164,8 +164,11 @@ public final class ApolloCodegen: Sendable {
   /// Performs GraphQL source validation and compiles the schema and operation source documents.
   func compileGraphQLResult() async throws -> CompilationResult {
     let frontend = try await GraphQLJSFrontend()
-    async let graphQLSchema = try createSchema(frontend)
-    async let operationsDocument = try createOperationsDocument(frontend)
+      // `async let` here can trigger a Swift concurrency runtime crash on Swift 6.3/macOS 26.
+      // Keep the work serialized until the toolchain bug is fixed.
+      // See https://github.com/swiftlang/swift/pull/87665 for more information.
+      let graphQLSchema = try await createSchema(frontend)
+      let operationsDocument = try await createOperationsDocument(frontend)
     let validationOptions = ValidationOptions(config: config)
 
     let graphqlErrors = try await frontend.validateDocument(


### PR DESCRIPTION
### Why

I noticed that code generation triggers a [swift compiler bug](https://github.com/swiftlang/swift/pull/87665) when used in a `AsyncParsableCommand`. I have identified the issue and provided a workaround. See link and attached crash log for details about the triggered bug. I have verified this fixes the issue by using a fork in my toolchain.

[crashlog.txt](https://github.com/user-attachments/files/26266115/crashlog.txt)

### How
As the issue is triggered by stack management of `async let`s, serializing the work via `let … = await` works around the issue.